### PR TITLE
BE-3734 Fixed missing commit mesage error

### DIFF
--- a/component.yaml
+++ b/component.yaml
@@ -7,7 +7,7 @@ inputs:
   defaultValue: "$AC_JIRA_HOST"
   isRequired: true
   title: Jira Host
-  description: "Your Jira subdomain. Example: `mysubdomain.atlassian.net`"  
+  description: "Your Jira subdomain. Example: `https://mysubdomain.atlassian.net`"  
   helpText:
 - key: "AC_JIRA_EMAIL"
   defaultValue: "$AC_JIRA_EMAIL"
@@ -47,11 +47,11 @@ inputs:
   helpText:
 - key: "AC_JIRA_TEMPLATE_V2"
   defaultValue: |
-    - **Date (UTC)**: AC_JIRA_DATE 
-    - **Appcircle Workflow Name**: $AC_WORKFLOW_NAME 
-    - **Commit ID**: $AC_GIT_COMMIT
-    - **Git Branch**: $AC_GIT_BRANCH 
-    - **Commit Message**: $AC_COMMIT_MESSAGE
+    - *Date (UTC)*: AC_JIRA_DATE 
+    - *Appcircle Workflow Name*: $AC_WORKFLOW_NAME 
+    - *Commit ID*: $AC_GIT_COMMIT
+    - *Git Branch*: $AC_GIT_BRANCH 
+    - *Commit Message*: $AC_COMMIT_MESSAGE
   isRequired: false
   editorType: textarea
   title: Comment Template

--- a/component.yaml
+++ b/component.yaml
@@ -46,10 +46,16 @@ inputs:
   description: "Transition ID or name for the successful step. If the previous state succeeds, you can optionally change the status of your issue."
   helpText:
 - key: "AC_JIRA_TEMPLATE_V2"
-  defaultValue: "Commit ID: $AC_GIT_COMMIT | Git Branch: $AC_GIT_BRANCH | Commit Message: $AC_COMMIT_MESSAGE | Appcircle Workflow Name: $AC_WORKFLOW_NAME | Date (UTC): AC_JIRA_DATE" 
+  defaultValue: |
+    - **Date (UTC)**: AC_JIRA_DATE 
+    - **Appcircle Workflow Name**: $AC_WORKFLOW_NAME 
+    - **Commit ID**: $AC_GIT_COMMIT
+    - **Git Branch**: $AC_GIT_BRANCH 
+    - **Commit Message**: $AC_COMMIT_MESSAGE
   isRequired: false
+  editorType: textarea
   title: Comment Template
-  description: "This comment template will be used to post a comment. Variables donated with `$` will be replaced during the build. In Jira API version **2**, templates can only be sent as text. [To modify the Jira API version, adjust the component version](https://docs.appcircle.io/workflows/common-workflow-steps/jira-comment/#jira-rest-api-version-reference)."
+  description: "This comment template will be used to post a comment. Variables donated with `$` will be replaced during the build. In Jira API version **2**, templates can only be sent as text. To modify the Jira API version, adjust it on the component version. For instance, to utilize API version `3`, update the component version to `3.0.*`. Explore the [Jira comment documentation](https://docs.appcircle.io/workflows/common-workflow-steps/jira-comment/#jira-rest-api-version-reference) for further details."
   helpText:
 - key: "AC_JIRA_TEMPLATE_V3"
   defaultValue: |

--- a/main.rb
+++ b/main.rb
@@ -116,8 +116,8 @@ def transitionid(id, transitions)
 end
 
 jira_host = env_has_key('AC_JIRA_HOST')
-commit_message = env_has_key('AC_COMMIT_MESSAGE')
-clean_commit_message(commit_message)
+commit_message = get_env('AC_COMMIT_MESSAGE')
+clean_commit_message(commit_message) if commit_message
 username = get_env('AC_JIRA_EMAIL')
 access_key = get_env('AC_JIRA_TOKEN')
 $jira_pat = get_env('AC_JIRA_PAT')

--- a/main.rb
+++ b/main.rb
@@ -109,7 +109,7 @@ end
 
 def transitionid(id, transitions)
   if is_integer?(id)
-    success_id
+    id
   else
     transitions[:transitions].find { |t| t[:name].casecmp(id).zero? }[:id]
   end


### PR DESCRIPTION
Updates:

- AC_COMMIT_MESSAGE was made optional
- Template text area and list were made for Jira API v2
- Added https:// to the example given in the Jira host description. Because this is mandatory.
- The error that occurred when transition_id was entered instead of transition_name was fixed.